### PR TITLE
Account support

### DIFF
--- a/src/main/java/edu/architect_711/wordsapp/controller/AccountController.java
+++ b/src/main/java/edu/architect_711/wordsapp/controller/AccountController.java
@@ -2,7 +2,7 @@ package edu.architect_711.wordsapp.controller;
 
 import edu.architect_711.wordsapp.model.dto.AccountDto;
 import edu.architect_711.wordsapp.model.dto.SaveAccountDto;
-import edu.architect_711.wordsapp.service.AccountService;
+import edu.architect_711.wordsapp.service.account.AccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/edu/architect_711/wordsapp/service/account/AccountService.java
+++ b/src/main/java/edu/architect_711/wordsapp/service/account/AccountService.java
@@ -1,4 +1,4 @@
-package edu.architect_711.wordsapp.service;
+package edu.architect_711.wordsapp.service.account;
 
 import edu.architect_711.wordsapp.model.dto.AccountDto;
 import edu.architect_711.wordsapp.model.dto.SaveAccountDto;

--- a/src/main/java/edu/architect_711/wordsapp/service/account/DefaultAccountService.java
+++ b/src/main/java/edu/architect_711/wordsapp/service/account/DefaultAccountService.java
@@ -1,4 +1,4 @@
-package edu.architect_711.wordsapp.service;
+package edu.architect_711.wordsapp.service.account;
 
 import edu.architect_711.wordsapp.model.dto.AccountDto;
 import edu.architect_711.wordsapp.model.dto.SaveAccountDto;

--- a/src/test/java/edu/architect_711/wordsapp/service/AccountServiceIntegrationTest.java
+++ b/src/test/java/edu/architect_711/wordsapp/service/AccountServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package edu.architect_711.wordsapp.service;
 import edu.architect_711.wordsapp.model.dto.AccountDto;
 import edu.architect_711.wordsapp.model.dto.SaveAccountDto;
 import edu.architect_711.wordsapp.repository.AccountRepository;
+import edu.architect_711.wordsapp.service.account.DefaultAccountService;
 import jakarta.transaction.Transactional;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.*;


### PR DESCRIPTION
## In Nutshell
Add accounts (and users) in the app. Tested!

## Features
* When a user makes a request to save his new account, he sends:
```json
{
    "username": "",
    "password": "",
    "email": ""
}
```
and gets in return saved account: the JSON response without password but with an id
* If a user tries to save/update an account with existing username/email, to find an account by unreal id, the `jakarta.persistence.EntityNotFoundException` appears, deletion by unreal id is silently ignored and no errors.

## Bugs, errors, TODOs
1. No security support, so any user can delete, update, get another user
2. No email verification
3. No API docs
4. No password reset

## Schema
![image](https://github.com/user-attachments/assets/12dc2043-d8cb-4bce-a1bc-15d024c5aa26)
