### PR TITLE
Add first version of Open API config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql:11.1.0'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/edu/architect_711/wordsapp/config/OpenAPIConfiguration.java
+++ b/src/main/java/edu/architect_711/wordsapp/config/OpenAPIConfiguration.java
@@ -1,0 +1,22 @@
+package edu.architect_711.wordsapp.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "The Swagger API documentation of the WordsApp", version = "0.0.1"),
+        security = @SecurityRequirement(name = "BasciAuth")
+)
+@SecurityScheme(
+        type = SecuritySchemeType.HTTP,
+        scheme = "basic",
+        name = "BasicAuth"
+)
+public class OpenAPIConfiguration {
+
+}

--- a/src/main/java/edu/architect_711/wordsapp/config/SecurityConfiguration.java
+++ b/src/main/java/edu/architect_711/wordsapp/config/SecurityConfiguration.java
@@ -20,7 +20,12 @@ public class SecurityConfiguration {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/api/languages/**").permitAll()
+                        .requestMatchers(
+                                "/api/languages/**",
+                                "/swagger-ui/**",
+                                "/api-docs.yaml",
+                                "/v3/api-docs/**"
+                        ).permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/accounts").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/accounts/login64").permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/edu/architect_711/wordsapp/controller/AccountController.java
+++ b/src/main/java/edu/architect_711/wordsapp/controller/AccountController.java
@@ -4,6 +4,7 @@ import edu.architect_711.wordsapp.model.dto.AccountDto;
 import edu.architect_711.wordsapp.model.dto.LoginRequest;
 import edu.architect_711.wordsapp.model.dto.SaveAccountDto;
 import edu.architect_711.wordsapp.service.account.AccountService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,11 +19,13 @@ public class AccountController {
         return accountService.get();
     }
 
+    @SecurityRequirements
     @PostMapping("/login64")
     public String login64(@RequestBody LoginRequest loginRequest) {
         return accountService.login64(loginRequest);
     }
 
+    @SecurityRequirements
     @PostMapping
     public AccountDto save(@RequestBody SaveAccountDto accountDto) {
         return accountService.save(accountDto);

--- a/src/main/java/edu/architect_711/wordsapp/controller/LanguageController.java
+++ b/src/main/java/edu/architect_711/wordsapp/controller/LanguageController.java
@@ -2,6 +2,7 @@ package edu.architect_711.wordsapp.controller;
 
 import edu.architect_711.wordsapp.model.dto.LanguageDto;
 import edu.architect_711.wordsapp.service.language.LanguageService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import java.util.List;
 public class LanguageController {
     private final LanguageService languageService;
 
+    @SecurityRequirements
     @GetMapping
     public List<LanguageDto> get() {
         return languageService.get();

--- a/src/main/java/edu/architect_711/wordsapp/model/dto/LanguageDto.java
+++ b/src/main/java/edu/architect_711/wordsapp/model/dto/LanguageDto.java
@@ -1,5 +1,7 @@
 package edu.architect_711.wordsapp.model.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class LanguageDto {
+    @NotNull
     private Long id;
+    @NotBlank
     private String title;
 }

--- a/src/main/java/edu/architect_711/wordsapp/model/dto/LoginRequest.java
+++ b/src/main/java/edu/architect_711/wordsapp/model/dto/LoginRequest.java
@@ -1,5 +1,6 @@
 package edu.architect_711.wordsapp.model.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,8 @@ import lombok.NoArgsConstructor;
 @Data @NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequest {
+    @NotBlank
     private String username;
+    @NotBlank
     private String password;
 }


### PR DESCRIPTION
## Description
Added the OpenAPI dependency to generate API docs and gracefully display it

## Features
* Display public and private endpoints
* Display DTOs and it's constraints (like username length)
* Security type info
* Public Swagger endpoints

## Example
![image](https://github.com/user-attachments/assets/ed808881-3210-4bac-9201-0b71349a6fe3)
